### PR TITLE
Add support for python3

### DIFF
--- a/bump_buildnum.py
+++ b/bump_buildnum.py
@@ -88,7 +88,7 @@ def upver(vername):
     return (version, build)
 
 if __name__ == "__main__":
-    if os.environ.has_key('ACTION') and os.environ['ACTION'] == 'clean':
+    if ('ACTION' in os.environ) and os.environ['ACTION'] == 'clean':
         print("{0}: Not running while cleaning".format(sys.argv[0]))
         sys.exit(0)
 

--- a/bump_buildnum.py
+++ b/bump_buildnum.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 #
 # Bump build number in Info.plist files if a source file have changed.
 #

--- a/copy_dylibs.py
+++ b/copy_dylibs.py
@@ -85,7 +85,7 @@ def change_install_names():
 				cmdline = ['install_name_tool', '-id', new_name, dylib]
 			else:
 				cmdline = ['install_name_tool', '-change', old_name, new_name, dylib]
-			print("Running", " ".join(cmdline))
+			print("Running: " + " ".join(cmdline))
 			exitcode = subprocess.call(cmdline)
 			if exitcode != 0:
 				raise RuntimeError("Failed to change '{0}' to '{1}' in '{2}".format(old_name, new_name, dylib))

--- a/copy_dylibs.py
+++ b/copy_dylibs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 """Copy dylibs into the build folder.
 

--- a/copy_dylibs.py
+++ b/copy_dylibs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """Copy dylibs into the build folder.
 
@@ -14,8 +14,7 @@ Copyright (c)2019 Andy Duplain <trojanfoe@gmail.com>
 
 """
 
-import sys, os, imp, traceback, shutil, subprocess, re
-from sets import Set
+import sys, os, traceback, shutil, subprocess, re
 
 frameworks_dir = None
 
@@ -27,7 +26,7 @@ frameworks_dir = None
 install_names = {}
 
 # List of dylibs copied
-copied_dylibs = Set()
+copied_dylibs = set()
 
 def copy_dylib(src):
 	global copied_dylibs
@@ -37,20 +36,20 @@ def copy_dylib(src):
 
 	if not os.path.exists(dest):
 		shutil.copyfile(src, dest)
-		os.chmod(dest, 0644)
+		os.chmod(dest, 0o644)
 		copy_dependencies(dest)
 		copied_dylibs.add(dest)
 	else:
-		print "'{0}' already exists, so not copying".format(dylib_filename)
+		print("'{0}' already exists, so not copying".format(dylib_filename))
 
 def copy_dependencies(file):
 	global install_names
 
 	(file_path, file_filename) = os.path.split(file)
-	print "Examining '{0}'".format(file_filename)
+	print("Examining '{0}'".format(file_filename))
 	pipe = subprocess.Popen(['otool', '-L', file], stdout=subprocess.PIPE)
 	while True:
-		line = pipe.stdout.readline()
+		line = pipe.stdout.readline().decode("utf-8")
 		if line == '':
 			break
 		# 	/opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
@@ -85,7 +84,7 @@ def change_install_names():
 				cmdline = ['install_name_tool', '-id', new_name, dylib]
 			else:
 				cmdline = ['install_name_tool', '-change', old_name, new_name, dylib]
-			print "Running", " ".join(cmdline)
+			print("Running", " ".join(cmdline))
 			exitcode = subprocess.call(cmdline)
 			if exitcode != 0:
 				raise RuntimeError("Failed to change '{0}' to '{1}' in '{2}".format(old_name, new_name, dylib))
@@ -131,5 +130,5 @@ if __name__ == "__main__":
 	try:
 		exitcode = main(sys.argv)
 	except Exception as e:
-		print traceback.format_exc()
+		print(traceback.format_exc())
 	sys.exit(exitcode)


### PR DESCRIPTION
These changes should work for python3.x and python2.7, which is the default python version since mac OS X Lion (10.7). I tested them for both versions on my machine, but it might be a good idea to test them on more systems to guarantee that they don't break anything.